### PR TITLE
Use right opts name for disabling watch

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ that combines together [district-ui-web3-accounts](https://github.com/district0x
 [district-ui-web3-balances](https://github.com/district0x/district-ui-web3-balances) to provide balances of user's accounts.  
 
 ## Installation
-Add `[district0x/district-ui-web3-account-balances "1.0.2"]` into your project.clj  
+Add [![Clojars Project](https://img.shields.io/clojars/v/district0x/district-ui-web3-account-balances.svg)](https://clojars.org/district0x/district-ui-web3-account-balances) into your project.clj  
 Include `[district.ui.web3-account-balances]` in your CLJS file, where you use `mount/start`
 
 ## API Overview

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject district0x/district-ui-web3-account-balances "1.0.2"
+(defproject district0x/district-ui-web3-account-balances "1.0.3"
   :description "district UI module for handling web3 account balances"
   :url "https://github.com/district0x/district-ui-web3-account-balances"
   :license {:name "Eclipse Public License"

--- a/src/district/ui/web3_account_balances.cljs
+++ b/src/district/ui/web3_account_balances.cljs
@@ -25,4 +25,4 @@
 
 
 (defn stop []
-  (dispatch-sync [::events/stop]))
+  (dispatch-sync [::events/stop @web3-account-balances]))


### PR DESCRIPTION
the option disable-loading-at-start? was being used for checking whether the balances need to be watched. This PR fixes this by using the existing disable-watching? opt instead.

Also, stop handling has been improved.