### PR TITLE
Fix groupid in some dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,10 +98,23 @@ Works the same way as sub `::accounts-balances`
 * [district-ui-web3-balances](https://github.com/district0x/district-ui-web3-balances)
 
 ## Development
-```bash
-lein deps
-# Start ganache blockchain
-ganache-cli -p 8549 -b 1 --noVMErrorsOnRPCResponse
-# To run tests and rerun on changes
-lein doo chrome tests
-```
+
+1. Setup local testnet
+
+- spin up a testnet instance in a separate shell
+  - `npx truffle develop`
+
+2. Run test suite:
+- Browser
+  - `npx shadow-cljs watch test-browser`
+  - open https://d0x-vm:6502
+  - tests refresh automatically on code change
+- CI (Headless Chrome, Karma)
+  - `npx shadow-cljs compile test-ci`
+  - ``CHROME_BIN=`which chromium-browser` npx karma start karma.conf.js --single-run``
+
+3. Build
+- on merging pull request to master on GitHub, CI builds & publishes new version automatically
+- update version in `build.clj`
+- to build: `clj -T:build jar`
+- to release: `clj -T:build deploy` (needs `CLOJARS_USERNAME` and `CLOJARS_PASSWORD` env vars to be set)

--- a/deps.edn
+++ b/deps.edn
@@ -7,8 +7,8 @@
   org.clojure/clojurescript {:mvn/version "1.11.60"}
   district0x/district-format {:mvn/version "1.0.6"}
   day8.re-frame/forward-events-fx {:mvn/version "0.0.6"}
-  district0x/district-ui-web3-balances {:mvn/version "1.1.0-SNAPSHOT" :exclusions [district0x/district-ui-smart-contracts]}
-  district0x/district-ui-web3-accounts {:mvn/version "1.1.0-SNAPSHOT"}
+  io.github.district0x/district-ui-web3-balances {:mvn/version "1.1.0-SNAPSHOT" :exclusions [district0x/district-ui-smart-contracts]}
+  io.github.district0x/district-ui-web3-accounts {:mvn/version "1.1.0-SNAPSHOT"}
   district0x/re-frame-spec-interceptors {:mvn/version "1.0.1"}
   re-frame/re-frame {:mvn/version "1.2.0"}
   mount/mount {:mvn/version "0.1.16"}}


### PR DESCRIPTION
latest version of district-ui-web3-balances and district-ui-web3-accounts are currently using the io.github.district0x groupid

Also fixed documentation for running using shadow-cljs